### PR TITLE
Add text-size crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 
 - [`codespan-reporting`](https://crates.io/crates/codespan-reporting) Beautiful diagnostic reporting for text-based programming languages
 - [`codespan`](https://crates.io/crates/codespan) Data structures for tracking locations in source code
-- [`text-unit`](https://crates.io/crates/text_unit) A library that provides newtype wrappers for `u32` and `(u32, u32)` for use as text offsets
+- [`text-size`](https://crates.io/crates/text_size) A library that provides newtype wrappers for `u32` and `(u32, u32)` for use as text offsets
     
 ## Language server protocol
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 
 - [`codespan-reporting`](https://crates.io/crates/codespan-reporting) Beautiful diagnostic reporting for text-based programming languages
 - [`codespan`](https://crates.io/crates/codespan) Data structures for tracking locations in source code
+- [`text-unit`](https://crates.io/crates/text_unit) A library that provides newtype wrappers for `u32` and `(u32, u32)` for use as text offsets
     
 ## Language server protocol
 


### PR DESCRIPTION
text-size is a small crate that can be used as a lightweight alternative to `codespan`.