### PR TITLE
add nimbleparse_lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 - [`pratt`](https://crates.io/crates/pratt) A general purpose pratt parser for Rust
 - [`pest`](https://crates.io/crates/pest) A general purpose parser written in Rust with a focus on accessibility, correctness, and performance using parsing expression grammars (PEG)
 - [`lrpar`](https://crates.io/crates/lrpar) A Yacc-compatible parser.
+  - [`nimbleparse_lsp`](https://github.com/ratmice/nimbleparse_lsp) An LSP server for quickly developing lrpar parsers, which parses input buffers on grammar change bypassing code generation.
 - [`tree-sitter`](https://tree-sitter.github.io/tree-sitter/) A parser generator for building fast editor-friendly parsers with features like streaming, incremental, resumable (re)parsing, with timeouts and cancellations, and advanced syntax node queries.
 - [`rowan`](https://crates.io/crates/rowan) Generic lossless syntax trees
   - [`ungrammar`](https://crates.io/crates/ungrammar) A DSL for specifying concrete syntax trees, see [this introductory post](https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html)


### PR DESCRIPTION
It might be early to add this, as it is still kind of undergoing development with just the first signs of becoming a useful tool.
It is kind of weird in the 'parser' category, I mean I guess it is a parser technically, more appropriately a parser development tool.
But I didn't want to split it up from lrpar, as it is inspired by a tool `nimbleparse` which comes with lrpar in lsp form.