### PR TITLE
remove lspower as lspower and tower-lsp unforked.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@
 - [`tower-lsp`](https://crates.io/crates/tower-lsp) Language Server Protocol implementation based on Tower
 - [`codespan-lsp`](https://crates.io/crates/codespan-lsp) Conversions between codespan types and Language Server Protocol types
 - [`lsp-server`](https://crates.io/crates/lsp-server) A generic LSP server scaffold
-- [`lspower`](https://crates.io/crates/lspower) Language Server Protocol implementation for Rust based on Tower. (Fork of `tower-lsp`)
     
 ## Testing
 


### PR DESCRIPTION
With the lspower repository archived after the lspower + tower-lsp unforking/merger, we might remove it.